### PR TITLE
Make source plugin check more specific.

### DIFF
--- a/kar-packager/src/main/java/com/crsn/maven/utils/osgirepo/util/OsgiToMavenMapper.java
+++ b/kar-packager/src/main/java/com/crsn/maven/utils/osgirepo/util/OsgiToMavenMapper.java
@@ -23,7 +23,7 @@ public class OsgiToMavenMapper {
       String groupId = createGroupId( plugin.getName() );
       String artifactId = createArtifactName( plugin.getName() );
       Version version = plugin.getVersion();
-      boolean isSourcePlugin = plugin.getName().endsWith( "source" );
+      boolean isSourcePlugin = plugin.getName().endsWith( ".source" );
       MavenArtifactBuilder artefactBuilder = isSourcePlugin
                                                            ? builder.addSourceArtifact()
                                                            : builder.addArtifact();


### PR DESCRIPTION
The current check incorrectly matches a plugin named, "some.plugin.group.datasource". Changed to look for bundle names ending with ".source".
